### PR TITLE
boards/PCEngines: add TrenchBoot (AMD, legacy, Linux) results

### DIFF
--- a/boards/PCEngines/README.md
+++ b/boards/PCEngines/README.md
@@ -1,0 +1,16 @@
+# What's this
+
+Results for TrenchBoot tests on hardware (specifically, on AMD).
+
+# How they were obtained
+
+By running `trenchboot/` tests from [this OSFV PR][osfv-pr] on a APU2C DUT
+with coreboot+SeaBIOS firmware and Linux from meta-trenchboot distribution built
+[at this PR][meta-trenchboot-pr] as:
+
+```
+CONFIG=pcengines-apu2 RTE_IP=192.168.10.172 SNIPEIT_NO=1 scripts/run.sh trenchboot/ -- -v SEABIOS_BOOT_DEVICE:1
+```
+
+[osfv-pr]: https://github.com/Dasharo/open-source-firmware-validation/pull/555
+[meta-trenchboot]: https://github.com/3mdeb/meta-trenchboot/pull/45

--- a/boards/PCEngines/results.csv
+++ b/boards/PCEngines/results.csv
@@ -1,0 +1,12 @@
+Test name,Test ID, PC Engines APU2C
+All cores are up,WOD001.001,PASS
+SRTM event log exists,WOD002.001,PASS
+DRTM PCRs are not updated without TB,WOD003.001,PASS
+DRTM event log doesn't exist,WOD004.001,PASS
+All cores are up,WTD001.001,PASS
+DRTM PCRs are updated with TB,WTD002.001,PASS
+SRTM event log exists,WTD003.001,PASS
+DRTM event log exists,WTD004.001,PASS
+DRTM event log has DRTM entries (AMD),WTD005.001,PASS
+DRTM log aligns with PCR values,WTD006.001,PASS
+SRTM log aligns with PCR values,WTD007.001,PASS

--- a/boards/PCEngines/results.csv.license
+++ b/boards/PCEngines/results.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 3mdeb Sp. z o. o.
+
+SPDX-License-Identifier: CC-BY-SA-4.0


### PR DESCRIPTION
Related PRs:
 - https://github.com/Dasharo/open-source-firmware-validation/pull/555
 - https://github.com/3mdeb/meta-trenchboot/pull/45